### PR TITLE
fix: Cannot read properties of undefined (reading 'find')

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -154,9 +154,22 @@ export class Client extends EventDeliver{
             const timer=setTimeout(()=>{
                 reject('初始化超时')
             },5000)
-            const bot=status.bots.find(bot=>bot.self?.user_id===this.uin+'')
+            if('bots' in status){
+                const bot=status.bots.find(bot=>bot.self?.user_id===this.uin+'')
+            }
+            else{
+                const bot=status
+            }
             if(status.good && bot?.online){
-                this.info=bot.self
+                if('self' in bot){
+                    this.info=bot.self
+                }
+                else{
+                    this.info={
+                        "platform": "qq",
+                        "user_id": String(this.uin)
+                    }
+                }
                 await callback()
                 clearTimeout(timer)
                 resolve()


### PR DESCRIPTION
OneBot中的`get_status`终结点会返回good(bool类型)和bots(list[object]类型)两个字段，而go-cqhttp的返回与其略有不同（https://docs.go-cqhttp.org/api/#%E8%8E%B7%E5%8F%96%E7%8A%B6%E6%80%81）
于是就出现了bug：Cannot read properties of undefined (reading 'find')
本PR对gocq的返回值做了兼容，让其可以自动识别是go-cqhttp端并且进行处理